### PR TITLE
add two options to custom default responses and output field

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -50,7 +50,13 @@ class SwaggerAPI {
    */
   generateSpec(baseSpec, options) {
     options = Object.assign({
-      warnFunc: console.warn
+      warnFunc: console.warn,
+      outputFunc: route => route.validate.output,
+      defaultResponses: {
+        200: {
+          description: 'Success'
+        }
+      }
     }, options);
 
     assert(baseSpec.info, 'baseSpec.info parameter missing');

--- a/lib/generator.js
+++ b/lib/generator.js
@@ -68,11 +68,7 @@ exports.routeToSwaggerPaths = function routeToSwaggerPaths(route, options) {
 
   let paths = {};
   let routeDesc = {
-    responses: {
-      200: {
-        description: 'Success'
-      }
-    }
+    responses: options.defaultResponses
   };
 
   if (route.validate) {
@@ -91,7 +87,7 @@ exports.routeToSwaggerPaths = function routeToSwaggerPaths(route, options) {
     routeDesc.parameters = exports.validateToSwaggerParameters(route.validate);
 
     // add responses from output schema
-    let output = route.validate.output;
+    let output = options.outputFunc(route);
     if (output) {
       Object.keys(output).forEach(x => {
         x = x.toString();

--- a/test/test-api.js
+++ b/test/test-api.js
@@ -42,7 +42,88 @@ describe('API', function () {
       },
       basePath: '/api'
     })
-    
     assert(['info', 'basePath', 'swagger', 'paths', 'tags'].every(v => v in spec))
+  });
+});
+
+describe('API', function () {
+  it('should success with empty defaultResponses', function () {
+    const generator = new SwaggerAPI();
+
+    const router = Router()
+
+    router.get('/no_200', {
+      meta: {
+        swagger: {
+          summary: 'no 200 doc'
+        }
+      },
+      validate: {
+        type: 'json',
+        body: {
+          hello: Joi.string().valid('world')
+        },
+        output: {
+          204: {
+            body: {
+              id: Joi.number().integer()
+            }
+          }
+        }
+      },
+      handler: async() => {}
+    })
+
+    generator.addJoiRouter(router);
+
+    const spec = generator.generateSpec({
+      info: {
+        title: 'Example API',
+        version: '1.1'
+      },
+      basePath: '/api'
+    },{defaultResponses: {}})
+    assert(!('200' in spec.paths['/no_200'].get.responses))
+  });
+});
+
+describe('API', function () {
+  it('should success with custom output', function () {
+    const generator = new SwaggerAPI();
+
+    const router = Router()
+
+    router.get('/custom_output', {
+      niconiconi: {
+        204: {
+          body: {
+            id: Joi.number().integer()
+          }
+        }
+      },
+      meta: {
+        swagger: {
+          summary: 'custom output doc'
+        }
+      },
+      validate: {
+        type: 'json',
+        body: {
+          hello: Joi.string().valid('world')
+        }
+      },
+      handler: async() => {}
+    })
+
+    generator.addJoiRouter(router);
+
+    const spec = generator.generateSpec({
+      info: {
+        title: 'Example API',
+        version: '1.1'
+      },
+      basePath: '/api'
+    },{outputFunc: route => route.niconiconi})
+    assert('204' in spec.paths['/custom_output'].get.responses)
   });
 });


### PR DESCRIPTION
Add new options `outputFunc` and `defaultResponses` in `generateSpec` to fix [this issue](https://github.com/o2team/koa-joi-router-docs/issues/1).
Please note that the new feature doesn't change the existing behavior without configurations  `outputFunc` and `defaultResponses`.