### PR TITLE
Fix: considering route.prefix

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -28,6 +28,8 @@ class SwaggerAPI {
     }
 
     router.routes.forEach(function(route) {
+      route.path = (router.router.opts.prefix || '') + route.path
+
       this.apiRoutes.push({
         route: route,
         prefix: options.prefix

--- a/test/test-api.js
+++ b/test/test-api.js
@@ -42,6 +42,44 @@ describe('API', function () {
     assert(['info', 'basePath', 'swagger', 'paths', 'tags'].every(v => v in spec))
   })
 
+  it('should consider the router prefix', function () {
+    const generator = new SwaggerAPI()
+    const router = Router()
+    router.prefix('/user')
+
+    router.get('/signup', {
+      meta: {
+        swagger: {
+          summary: 'User Signup'
+        }
+      },
+      validate: {
+        type: 'json',
+        body: {
+          username: Joi.string().alphanum().min(3).max(30).required()
+        },
+        output: {
+          200: {
+            body: {
+              userId: Joi.string().description('Newly created user id')
+            }
+          }
+        }
+      },
+      handler: async () => {}
+    })
+
+    generator.addJoiRouter(router)
+    const spec = generator.generateSpec({
+      info: {
+        title: 'Example API',
+        version: '1.1'
+      },
+      basePath: '/'
+    })
+    assert(['/user/signup'].every( r => r in spec.paths))
+  })
+
   it('should success with empty default response', function () {
     const generator = new SwaggerAPI()
     const router = Router()


### PR DESCRIPTION
The `addJoiRouter` was ignoring the `route.prefix()` method in `koa-joi-router`.

I also wrote a test case for that.

If you you see any improvement, just say and i'll change it.